### PR TITLE
Fix(parser): Normalize trusted zone parameter casing

### DIFF
--- a/threat_analysis/core/model_parser.py
+++ b/threat_analysis/core/model_parser.py
@@ -200,6 +200,13 @@ class ModelParser:
                         value = value_unquoted
             else:
                 continue
+
+            # Normalize keys to handle case variations
+            if key.lower() == 'istrusted':
+                key = 'isTrusted'
+            elif key.lower() == 'isfilled':
+                key = 'isFilled'
+
             params[key] = value
         return params
 


### PR DESCRIPTION
Some threat models used `istrusted=true` while others used `isTrusted=true` to define trusted zones. The model parser was case-sensitive, causing it to misinterpret `istrusted` and fail to apply the correct styling (a red border) for trusted zones in the GUI.

This commit modifies the key-value parser to normalize the `isTrusted` and `isFilled` keys to their correct camelCase form. This ensures that these properties are recognized consistently across all threat models, regardless of the casing used in the source files.