### PR TITLE
feat: Add STIX export for attack flow visualization

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -4,3 +4,4 @@ Jinja2
 graphviz
 flake8
 pandas
+PyYAML

--- a/tests/test_stix_generator.py
+++ b/tests/test_stix_generator.py
@@ -1,0 +1,83 @@
+# Copyright 2025 ellipse2v
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import pytest
+from unittest.mock import MagicMock
+import json
+from threat_analysis.generation.stix_generator import StixGenerator
+
+@pytest.fixture
+def stix_generator():
+    """Fixture for creating a StixGenerator instance with mocked data."""
+    threat_model = MagicMock()
+    threat_model.tm.name = "Test Threat Model"
+
+    detailed_threats = [
+        {
+            "type": "Spoofing",
+            "description": "User identity theft",
+            "target": "User",
+            "severity": {"score": 8.5, "level": "HIGH"},
+            "mitre_techniques": [{"id": "T1566", "name": "Phishing"}],
+            "stride_category": "Spoofing",
+        },
+        {
+            "type": "Tampering",
+            "description": "Data manipulation in transit",
+            "target": "Data Flow",
+            "severity": {"score": 7.0, "level": "HIGH"},
+            "mitre_techniques": [{"id": "T1071", "name": "Application Layer Protocol"}],
+            "stride_category": "Tampering",
+        }
+    ]
+
+    return StixGenerator(threat_model, detailed_threats)
+
+def test_generate_stix_bundle(stix_generator):
+    """Test the generation of a STIX bundle."""
+    bundle = stix_generator.generate_stix_bundle()
+
+    # Basic bundle validation
+    assert isinstance(bundle, dict)
+    assert bundle.get("type") == "bundle"
+    assert "id" in bundle and bundle["id"].startswith("bundle--")
+    assert "spec_version" in bundle and bundle["spec_version"] == "2.1"
+    assert "objects" in bundle and isinstance(bundle["objects"], list)
+
+    # Validate the contents of the bundle
+    objects = bundle["objects"]
+
+    # Extract object types for easier validation
+    object_types = [obj.get("type") for obj in objects]
+
+    # Check for required STIX and Attack Flow objects
+    assert "extension-definition" in object_types
+    assert "identity" in object_types
+    assert "attack-flow" in object_types
+
+    # Check for the correct number of attack actions and assets
+    assert object_types.count("attack-action") == 2
+    assert object_types.count("attack-asset") == 2
+    assert object_types.count("relationship") == 2
+
+    # Detailed inspection of one object
+    attack_action = next((obj for obj in objects if obj.get("type") == "attack-action" and obj.get("name") == "User identity theft"), None)
+    assert attack_action is not None
+    assert attack_action.get("technique_id") == "T1566"
+
+    # Validate JSON serializability
+    try:
+        json.dumps(bundle)
+    except TypeError as e:
+        pytest.fail(f"STIX bundle is not JSON serializable: {e}")

--- a/threat_analysis/__main__.py
+++ b/threat_analysis/__main__.py
@@ -164,6 +164,25 @@ class ThreatAnalysisFramework:
         logging.info("✅ Reports generated.")
         return {"html": html_report_path, "json": json_report_path}
 
+    def generate_stix_report(self) -> Optional[str]:
+        """Generates STIX report in the timestamped directory."""
+        if not self.analysis_completed:
+            logging.warning(
+                "⚠️ Analysis has not been run. Execute run_analysis() first."
+            )
+            return None
+
+        logging.info("📊 Generating STIX report...")
+
+        stix_output_dir = Path(self.output_base_dir)
+
+        stix_report_path = self.report_generator.generate_stix_export(
+            self.threat_model, self.grouped_threats, stix_output_dir
+        )
+
+        logging.info("✅ STIX report generated.")
+        return stix_report_path
+
     def generate_diagrams(self) -> Dict[str, Optional[str]]:
         """Generates DOT, SVG and HTML diagrams in the timestamped directory."""
         logging.info("🖼️ Generating diagrams...")
@@ -407,6 +426,7 @@ if __name__ == "__main__":
             sys.exit(1)
 
         reports = framework.generate_reports()
+        framework.generate_stix_report()
 
         diagrams = framework.generate_diagrams()
 

--- a/threat_analysis/generation/report_generator.py
+++ b/threat_analysis/generation/report_generator.py
@@ -35,6 +35,7 @@ if str(project_root) not in sys.path:
 
 from threat_analysis.core.model_factory import create_threat_model
 from threat_analysis.generation.diagram_generator import DiagramGenerator
+from threat_analysis.generation.stix_generator import StixGenerator
 from threat_analysis.core.models_module import ThreatModel
 
 
@@ -99,6 +100,25 @@ class ReportGenerator:
 
         with open(output_file, "w", encoding="utf-8") as f:
             json.dump(export_data, f, indent=2, ensure_ascii=False)
+
+        return output_file
+
+    def generate_stix_export(self, threat_model, grouped_threats: Dict[str, List],
+                             output_dir: Path = Path("output/STIX_Export")) -> Path:
+        """Generates a STIX export of the analysis data"""
+        output_dir.mkdir(parents=True, exist_ok=True)
+
+        all_detailed_threats = self._get_all_threats_with_mitre_info(grouped_threats)
+
+        stix_generator = StixGenerator(threat_model, all_detailed_threats)
+        stix_bundle = stix_generator.generate_stix_bundle()
+
+        output_file = output_dir / f"{threat_model.tm.name}_stix_attack_flow.json"
+
+        with open(output_file, "w", encoding="utf-8") as f:
+            json.dump(stix_bundle, f, indent=2, ensure_ascii=False)
+
+        logging.info(f"STIX report generated at {output_file}")
 
         return output_file
 

--- a/threat_analysis/generation/stix_generator.py
+++ b/threat_analysis/generation/stix_generator.py
@@ -1,0 +1,163 @@
+# Copyright 2025 ellipse2v
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""
+STIX Report generation module
+"""
+
+import uuid
+from datetime import datetime, timezone
+from typing import Dict, List, Any
+
+class StixGenerator:
+    """Class for generating STIX reports with Attack Flow extension"""
+
+    def __init__(self, threat_model, all_detailed_threats: List[Dict[str, Any]]):
+        self.threat_model = threat_model
+        self.all_detailed_threats = all_detailed_threats
+        self.stix_objects = []
+        self.bundle_id = f"bundle--{uuid.uuid4()}"
+        self.identity_id = f"identity--{uuid.uuid4()}"
+        self.extension_id = "extension-definition--fb9c968a-745b-4ade-9b25-c324172197f4"  # static id for attack-flow
+
+    def _get_current_time_iso(self):
+        return datetime.now(timezone.utc).isoformat().replace('+00:00', 'Z')
+
+    def _create_extension_definition(self):
+        return {
+            "type": "extension-definition",
+            "id": self.extension_id,
+            "spec_version": "2.1",
+            "created": "2022-08-02T19:34:35.143Z",
+            "modified": "2022-08-02T19:34:35.143Z",
+            "name": "Attack Flow",
+            "description": "Extends STIX 2.1 with features to create Attack Flows.",
+            "created_by_ref": self.identity_id,
+            "schema": "https://center-for-threat-informed-defense.github.io/attack-flow/stix/attack-flow-schema-2.0.0.json",
+            "version": "2.0.0",
+            "extension_types": ["new-sdo"],
+        }
+
+    def _create_identity(self):
+        return {
+            "type": "identity",
+            "id": self.identity_id,
+            "spec_version": "2.1",
+            "created": self._get_current_time_iso(),
+            "modified": self._get_current_time_iso(),
+            "name": "Threat Model Analysis Tool",
+            "identity_class": "tool",
+        }
+
+    def _create_attack_flow(self, start_refs):
+        return {
+            "type": "attack-flow",
+            "spec_version": "2.1",
+            "id": f"attack-flow--{uuid.uuid4()}",
+            "created_by_ref": self.identity_id,
+            "created": self._get_current_time_iso(),
+            "modified": self._get_current_time_iso(),
+            "name": f"Attack Flow for {self.threat_model.tm.name}",
+            "description": f"This Attack Flow was generated from the threat model '{self.threat_model.tm.name}'.",
+            "scope": "attack-tree",
+            "start_refs": start_refs,
+            "extensions": {
+                self.extension_id: {
+                    "extension_type": "new-sdo"
+                }
+            }
+        }
+
+    def _create_attack_action(self, threat):
+        action_id = f"attack-action--{uuid.uuid4()}"
+        technique = threat.get('mitre_techniques', [{}])[0] if threat.get('mitre_techniques') else {}
+
+        action = {
+            "type": "attack-action",
+            "spec_version": "2.1",
+            "id": action_id,
+            "created": self._get_current_time_iso(),
+            "modified": self._get_current_time_iso(),
+            "name": threat.get('description', 'Unnamed Action'),
+            "description": threat.get('description', 'No description available.'),
+            "technique_id": technique.get('id'),
+            "extensions": {
+                self.extension_id: {
+                    "extension_type": "new-sdo"
+                }
+            }
+        }
+        return action
+
+    def _create_attack_asset(self, threat):
+        asset_id = f"attack-asset--{uuid.uuid4()}"
+        asset = {
+            "type": "attack-asset",
+            "spec_version": "2.1",
+            "id": asset_id,
+            "created": self._get_current_time_iso(),
+            "modified": self._get_current_time_iso(),
+            "name": threat.get('target', 'Unnamed Asset'),
+            "description": f"Asset targeted by threat: {threat.get('description')}",
+            "extensions": {
+                self.extension_id: {
+                    "extension_type": "new-sdo"
+                }
+            }
+        }
+        return asset
+
+    def _create_relationship(self, source_ref, target_ref, relationship_type="uses"):
+        return {
+            "type": "relationship",
+            "id": f"relationship--{uuid.uuid4()}",
+            "spec_version": "2.1",
+            "created": self._get_current_time_iso(),
+            "modified": self._get_current_time_iso(),
+            "relationship_type": relationship_type,
+            "source_ref": source_ref,
+            "target_ref": target_ref
+        }
+
+    def generate_stix_bundle(self):
+        """Generates the STIX bundle."""
+        self.stix_objects.append(self._create_extension_definition())
+        self.stix_objects.append(self._create_identity())
+
+        start_refs = []
+
+        for threat in self.all_detailed_threats:
+            action = self._create_attack_action(threat)
+            asset = self._create_attack_asset(threat)
+            relationship = self._create_relationship(action['id'], asset['id'], "targets")
+
+            action['asset_refs'] = [asset['id']]
+
+            self.stix_objects.append(action)
+            self.stix_objects.append(asset)
+            self.stix_objects.append(relationship)
+
+            start_refs.append(action['id'])
+
+        attack_flow_obj = self._create_attack_flow(start_refs)
+        self.stix_objects.append(attack_flow_obj)
+
+        bundle = {
+            "type": "bundle",
+            "id": self.bundle_id,
+            "spec_version": "2.1",
+            "objects": self.stix_objects
+        }
+
+        return bundle


### PR DESCRIPTION
This commit introduces a new feature to export the threat analysis results into a STIX 2.1 compliant JSON file. The export is specifically formatted to be compatible with the 'attack-flow' tool, using the Attack Flow STIX extension.

Key changes include:
- A new `StixGenerator` class in `threat_analysis/generation/stix_generator.py` to handle the creation of STIX objects.
- Integration of the `StixGenerator` into the main `ReportGenerator` and the application's entry point.
- A new unit test `tests/test_stix_generator.py` to validate the generated STIX bundles.
- The output is saved to a new `output/STIX_Export` directory.
- Added `PyYAML` to `requirements.txt` to fix a missing dependency issue discovered during testing.