### PR TITLE
fix(server): resolve GDAF context file not found issue

### DIFF
--- a/threat_analysis/server/server.py
+++ b/threat_analysis/server/server.py
@@ -980,8 +980,8 @@ def generate_all():
         # When the browser explicitly sends "extra_files" (even an empty list), it has taken
         # ownership of BOM/context delivery — skip the server-side filesystem copy (1c) to
         # prevent stale server globals from contaminating the output with a different project.
-        browser_managed_files = "extra_files" in data
         extra_files = data.get("extra_files", [])
+        browser_managed_files = len(extra_files) > 0
         for ef in extra_files:
             ef_path = ef.get("path", "").lstrip('./\\')
             ef_content = ef.get("content", "")


### PR DESCRIPTION
When browser sends empty extra_files list in Web mode, context/ and BOM/ directories were not copied to generation_dir, causing GDAF engine to skip context file loading and produce 0 attack scenarios.

Fix by checking if extra_files is non-empty instead of just checking key existence.

Fixes: GDAF produced 0 scenarios due to missing context/iot_context.yaml