### PR TITLE
fix: Display GDAF scenarios in global project report

### DIFF
--- a/threat_analysis/generation/report_generator.py
+++ b/threat_analysis/generation/report_generator.py
@@ -28,7 +28,7 @@ from jinja2 import Environment, FileSystemLoader
 import os
 from pathlib import Path
 from collections import defaultdict
-from threat_analysis.utils import _validate_path_within_project
+from threat_analysis.utils import _validate_path_within_project, resolve_gdaf_context, resolve_bom_directory
 from threat_analysis.mitigation_suggestions import get_framework_mitigation_suggestions
 from threat_analysis.core.cve_service import CVEService
 from threat_analysis.core.threat_ranker import rank_and_trim
@@ -1513,6 +1513,9 @@ class ReportGenerator:
             dummy_model.dataflows.extend(model.dataflows)
 
         # Copy gdaf_scenarios from main_threat_model (if available)
+        # NOTE: all_models[0] is guaranteed to be the main_threat_model due to the
+        # ordering in generate_project_reports() where main_threat_model is built first
+        # and all_processed_models is constructed as [main_threat_model] + sub_models.
         if all_models:
             main_model = all_models[0]
             if hasattr(main_model, 'gdaf_scenarios') and main_model.gdaf_scenarios:
@@ -1526,80 +1529,6 @@ class ReportGenerator:
             report_title="🛡️ Global Project Threat Model Report"
         )
         logging.info(f"✅ Generated global project report with {len(all_threats_details)} total threats at {output_dir / 'global_threat_report.html'}")
-
-    def _resolve_gdaf_context(self, threat_model) -> Optional[str]:
-        """Resolve the GDAF context file path for a given threat model.
-        
-        Priority order:
-        1. `gdaf_context` key in the model's ## Context DSL section
-        2. `{model_parent}/context/` directory (first .yaml/.yml found)
-        3. `config/context.yaml` (project default fallback)
-        
-        Returns the resolved path as a string, or None if no context file is found.
-        """
-        from pathlib import Path
-        
-        ctx_cfg = getattr(threat_model, "context_config", {})
-        dsl_path = ctx_cfg.get("gdaf_context")
-        model_path = getattr(threat_model, "_model_file_path", None)
-        
-        if dsl_path:
-            # Resolve relative to model file directory first
-            if model_path:
-                p = Path(model_path).parent / dsl_path
-                if p.exists():
-                    logging.info("GDAF: using context from DSL ## Context: %s", p)
-                    return str(p)
-            p = Path(dsl_path)
-            if p.exists():
-                logging.info("GDAF: using context from DSL ## Context: %s", p)
-                return str(p)
-            logging.warning("GDAF: gdaf_context '%s' declared in ## Context but file not found", dsl_path)
-        
-        # Check model parent context/ subdirectory
-        if model_path:
-            context_dir = Path(model_path).parent / "context"
-            if context_dir.exists():
-                yaml_files = list(context_dir.glob("*.yaml")) + list(context_dir.glob("*.yml"))
-                if yaml_files:
-                    logging.info("GDAF: using context from model context/ dir: %s", yaml_files[0])
-                    return str(yaml_files[0])
-        
-        # Fallback: project default
-        fallback = Path("config/context.yaml")
-        if fallback.exists():
-            return str(fallback)
-        return None
-
-    def _resolve_bom_directory(self, threat_model) -> Optional[str]:
-        """Resolve BOM directory: DSL ## Context bom_directory → {model_parent}/BOM/ → None."""
-        from pathlib import Path
-        
-        ctx_cfg = getattr(threat_model, "context_config", {})
-        dsl_path = ctx_cfg.get("bom_directory")
-        model_path = getattr(threat_model, "_model_file_path", None)
-        
-        if dsl_path:
-            # Resolve relative to model file directory first
-            if model_path:
-                p = Path(model_path).parent / dsl_path
-                if p.exists():
-                    logging.info("BOM: using directory from DSL ## Context: %s", p)
-                    return str(p)
-            p = Path(dsl_path)
-            if p.exists():
-                logging.info("BOM: using directory from DSL ## Context: %s", p)
-                return str(p)
-            logging.warning("BOM: bom_directory '%s' declared in ## Context but not found", dsl_path)
-        
-        # Auto-discover from model file parent
-        if model_path:
-            bom_dir = Path(model_path).parent / "BOM"
-            if bom_dir.exists() and bom_dir.is_dir():
-                n_files = len(list(bom_dir.glob("*.json")) + list(bom_dir.glob("*.yaml")) + list(bom_dir.glob("*.yml")))
-                logging.info("BOM: auto-discovered %s (%d asset file(s))", bom_dir, n_files)
-                return str(bom_dir)
-        return None
 
     def generate_project_reports(self, project_path: Path, output_dir: Path, progress_callback = None, ai_service=None) -> Optional[ThreatModel]:
         """
@@ -1709,11 +1638,11 @@ class ReportGenerator:
             try:
                 from threat_analysis.core.gdaf_engine import GDAFEngine
                 from threat_analysis.generation.attack_flow_builder import AttackFlowBuilder
-                _context_path = self._resolve_gdaf_context(main_threat_model)
+                _context_path = resolve_gdaf_context(main_threat_model)
                 if _context_path:
                     if progress_callback: progress_callback(94, "Running GDAF cross-model analysis...")
                     _extra = getattr(main_threat_model, "sub_models", [])
-                    _bom_dir = self._resolve_bom_directory(main_threat_model)
+                    _bom_dir = resolve_bom_directory(main_threat_model)
                     _gdaf = GDAFEngine(main_threat_model, _context_path, extra_models=_extra, bom_directory=_bom_dir)
                     _scenarios = _gdaf.run()
                     if _scenarios:

--- a/threat_analysis/generation/report_generator.py
+++ b/threat_analysis/generation/report_generator.py
@@ -1512,6 +1512,12 @@ class ReportGenerator:
         for model in all_models:
             dummy_model.dataflows.extend(model.dataflows)
 
+        # Copy gdaf_scenarios from main_threat_model (if available)
+        if all_models:
+            main_model = all_models[0]
+            if hasattr(main_model, 'gdaf_scenarios') and main_model.gdaf_scenarios:
+                dummy_model.gdaf_scenarios = main_model.gdaf_scenarios
+
         self.generate_html_report(
             threat_model=dummy_model,
             grouped_threats={},
@@ -1520,6 +1526,80 @@ class ReportGenerator:
             report_title="🛡️ Global Project Threat Model Report"
         )
         logging.info(f"✅ Generated global project report with {len(all_threats_details)} total threats at {output_dir / 'global_threat_report.html'}")
+
+    def _resolve_gdaf_context(self, threat_model) -> Optional[str]:
+        """Resolve the GDAF context file path for a given threat model.
+        
+        Priority order:
+        1. `gdaf_context` key in the model's ## Context DSL section
+        2. `{model_parent}/context/` directory (first .yaml/.yml found)
+        3. `config/context.yaml` (project default fallback)
+        
+        Returns the resolved path as a string, or None if no context file is found.
+        """
+        from pathlib import Path
+        
+        ctx_cfg = getattr(threat_model, "context_config", {})
+        dsl_path = ctx_cfg.get("gdaf_context")
+        model_path = getattr(threat_model, "_model_file_path", None)
+        
+        if dsl_path:
+            # Resolve relative to model file directory first
+            if model_path:
+                p = Path(model_path).parent / dsl_path
+                if p.exists():
+                    logging.info("GDAF: using context from DSL ## Context: %s", p)
+                    return str(p)
+            p = Path(dsl_path)
+            if p.exists():
+                logging.info("GDAF: using context from DSL ## Context: %s", p)
+                return str(p)
+            logging.warning("GDAF: gdaf_context '%s' declared in ## Context but file not found", dsl_path)
+        
+        # Check model parent context/ subdirectory
+        if model_path:
+            context_dir = Path(model_path).parent / "context"
+            if context_dir.exists():
+                yaml_files = list(context_dir.glob("*.yaml")) + list(context_dir.glob("*.yml"))
+                if yaml_files:
+                    logging.info("GDAF: using context from model context/ dir: %s", yaml_files[0])
+                    return str(yaml_files[0])
+        
+        # Fallback: project default
+        fallback = Path("config/context.yaml")
+        if fallback.exists():
+            return str(fallback)
+        return None
+
+    def _resolve_bom_directory(self, threat_model) -> Optional[str]:
+        """Resolve BOM directory: DSL ## Context bom_directory → {model_parent}/BOM/ → None."""
+        from pathlib import Path
+        
+        ctx_cfg = getattr(threat_model, "context_config", {})
+        dsl_path = ctx_cfg.get("bom_directory")
+        model_path = getattr(threat_model, "_model_file_path", None)
+        
+        if dsl_path:
+            # Resolve relative to model file directory first
+            if model_path:
+                p = Path(model_path).parent / dsl_path
+                if p.exists():
+                    logging.info("BOM: using directory from DSL ## Context: %s", p)
+                    return str(p)
+            p = Path(dsl_path)
+            if p.exists():
+                logging.info("BOM: using directory from DSL ## Context: %s", p)
+                return str(p)
+            logging.warning("BOM: bom_directory '%s' declared in ## Context but not found", dsl_path)
+        
+        # Auto-discover from model file parent
+        if model_path:
+            bom_dir = Path(model_path).parent / "BOM"
+            if bom_dir.exists() and bom_dir.is_dir():
+                n_files = len(list(bom_dir.glob("*.json")) + list(bom_dir.glob("*.yaml")) + list(bom_dir.glob("*.yml")))
+                logging.info("BOM: auto-discovered %s (%d asset file(s))", bom_dir, n_files)
+                return str(bom_dir)
+        return None
 
     def generate_project_reports(self, project_path: Path, output_dir: Path, progress_callback = None, ai_service=None) -> Optional[ThreatModel]:
         """
@@ -1624,6 +1704,30 @@ class ReportGenerator:
                         logging.info("Cross-model RAG: added %d global threats to main model.", len(rag_threats))
                 except Exception as exc:
                     logging.warning("Cross-model RAG analysis failed (non-fatal): %s", exc)
+
+            # GDAF: Goal-Driven Attack Flow (run BEFORE global report so scenarios are available)
+            try:
+                from threat_analysis.core.gdaf_engine import GDAFEngine
+                from threat_analysis.generation.attack_flow_builder import AttackFlowBuilder
+                _context_path = self._resolve_gdaf_context(main_threat_model)
+                if _context_path:
+                    if progress_callback: progress_callback(94, "Running GDAF cross-model analysis...")
+                    _extra = getattr(main_threat_model, "sub_models", [])
+                    _bom_dir = self._resolve_bom_directory(main_threat_model)
+                    _gdaf = GDAFEngine(main_threat_model, _context_path, extra_models=_extra, bom_directory=_bom_dir)
+                    _scenarios = _gdaf.run()
+                    if _scenarios:
+                        main_threat_model.gdaf_scenarios = _scenarios
+                        _builder = AttackFlowBuilder(_scenarios, model_name=str(main_threat_model.tm.name))
+                        _builder.generate_and_save(str(output_dir))
+                        logging.info(
+                            "GDAF (project): %d scenarios from %d model(s) in %s/gdaf",
+                            len(_scenarios), 1 + len(_extra), output_dir,
+                        )
+                    else:
+                        logging.info("GDAF (project): no scenarios produced")
+            except Exception as _gdaf_exc:
+                logging.warning("GDAF (project) generation skipped (non-fatal): %s", _gdaf_exc)
 
             if progress_callback: progress_callback(95, "Generating global project report...")
             self.generate_global_project_report(all_processed_models, output_dir)

--- a/threat_analysis/server/ai_service.py
+++ b/threat_analysis/server/ai_service.py
@@ -157,11 +157,11 @@ class AIService:
     def _load_model_context(self, threat_model) -> Dict[str, Any]:
         """Load the model-specific GDAF context file and extract AI-relevant fields.
 
-        Uses the same resolution order as ExportService._resolve_gdaf_context():
+        Uses the same resolution order as utils.resolve_gdaf_context():
           1. gdaf_context key in ## Context DSL section (relative to model file)
           2. {model_dir}/context/*.yaml auto-discovery
           3. Returns {} if nothing found (no fallback to config/context.yaml —
-             that is loaded separately by _load_context()).
+              that is loaded separately by _load_context()).
 
         Extracted fields merged into the AI prompt context:
           sector, compliance_requirements, data_sensitivity,

--- a/threat_analysis/server/export_service.py
+++ b/threat_analysis/server/export_service.py
@@ -222,29 +222,6 @@ class ExportService:
                     "html": f"{model_name}_diagram.html",
                     "svg": f"{model_name}.svg"
                 }
-
-                # GDAF in project mode: unified graph across main + all sub-models
-                try:
-                    from threat_analysis.core.gdaf_engine import GDAFEngine
-                    from threat_analysis.generation.attack_flow_builder import AttackFlowBuilder
-                    _context_path = self._resolve_gdaf_context(main_threat_model)
-                    if _context_path:
-                        _extra = getattr(main_threat_model, "sub_models", [])
-                        _bom_dir = self._resolve_bom_directory(main_threat_model)
-                        _gdaf = GDAFEngine(main_threat_model, _context_path, extra_models=_extra, bom_directory=_bom_dir)
-                        _scenarios = _gdaf.run()
-                        if _scenarios:
-                            main_threat_model.gdaf_scenarios = _scenarios
-                            _builder = AttackFlowBuilder(_scenarios, model_name=str(model_name))
-                            _builder.generate_and_save(str(export_path))
-                            logging.info(
-                                "GDAF (project): %d scenarios from %d model(s) in %s/gdaf",
-                                len(_scenarios), 1 + len(_extra), export_path,
-                            )
-                        else:
-                            logging.info("GDAF (project): no scenarios produced")
-                except Exception as _gdaf_exc:
-                    logging.warning("GDAF (project) generation skipped (non-fatal): %s", _gdaf_exc)
         else:
             logging.info("--- Starting Single-File Generation (Server Mode) ---")
             threat_model = create_threat_model(

--- a/threat_analysis/server/export_service.py
+++ b/threat_analysis/server/export_service.py
@@ -30,6 +30,7 @@ from threat_analysis.core.model_validator import ModelValidator
 from threat_analysis.generation.attack_navigator_generator import AttackNavigatorGenerator
 from threat_analysis.generation.stix_generator import StixGenerator
 from threat_analysis.generation.attack_flow_generator import AttackFlowGenerator
+from threat_analysis.utils import resolve_gdaf_context, resolve_bom_directory
 
 TIMESTAMP_FORMAT = "%Y-%m-%d_%H-%M-%S"
 OUTPUT_BASE_DIR_TPL = "output"
@@ -49,72 +50,6 @@ class ExportService:
     def _get_output_dir(self):
         timestamp = datetime.datetime.now().strftime(TIMESTAMP_FORMAT)
         return Path(OUTPUT_BASE_DIR_TPL) / timestamp
-
-    def _resolve_gdaf_context(self, threat_model) -> Optional[str]:
-        """Resolve the GDAF context file path for a given threat model.
-
-        Priority order:
-        1. `gdaf_context` key in the model's ## Context DSL section
-           (resolved relative to model file directory, then CWD)
-        2. `{model_parent}/context/` directory (first .yaml/.yml found)
-        3. `config/context.yaml` (project default fallback)
-
-        Returns the resolved path as a string, or None if no context file is found.
-        """
-        ctx_cfg = getattr(threat_model, "context_config", {})
-        dsl_path = ctx_cfg.get("gdaf_context")
-        model_path = getattr(threat_model, "_model_file_path", None)
-        if dsl_path:
-            # Resolve relative to model file directory first (fixes CLI single-model mode)
-            if model_path:
-                p = Path(model_path).parent / dsl_path
-                if p.exists():
-                    logging.info("GDAF: using context from DSL ## Context: %s", p)
-                    return str(p)
-            p = Path(dsl_path)
-            if p.exists():
-                logging.info("GDAF: using context from DSL ## Context: %s", p)
-                return str(p)
-            logging.warning("GDAF: gdaf_context '%s' declared in ## Context but file not found", dsl_path)
-        # Check model parent context/ subdirectory
-        if model_path:
-            context_dir = Path(model_path).parent / "context"
-            if context_dir.exists():
-                yaml_files = list(context_dir.glob("*.yaml")) + list(context_dir.glob("*.yml"))
-                if yaml_files:
-                    logging.info("GDAF: using context from model context/ dir: %s", yaml_files[0])
-                    return str(yaml_files[0])
-        # Fallback: project default
-        fallback = Path("config/context.yaml")
-        if fallback.exists():
-            return str(fallback)
-        return None
-
-    def _resolve_bom_directory(self, threat_model) -> Optional[str]:
-        """Resolve BOM directory: DSL ## Context bom_directory → {model_parent}/BOM/ → None."""
-        ctx_cfg = getattr(threat_model, "context_config", {})
-        dsl_path = ctx_cfg.get("bom_directory")
-        model_path = getattr(threat_model, "_model_file_path", None)
-        if dsl_path:
-            # Resolve relative to model file directory first (fixes CLI single-model mode)
-            if model_path:
-                p = Path(model_path).parent / dsl_path
-                if p.exists():
-                    logging.info("BOM: using directory from DSL ## Context: %s", p)
-                    return str(p)
-            p = Path(dsl_path)
-            if p.exists():
-                logging.info("BOM: using directory from DSL ## Context: %s", p)
-                return str(p)
-            logging.warning("BOM: bom_directory '%s' declared in ## Context but not found", dsl_path)
-        # Auto-discover from model file parent
-        if model_path:
-            bom_dir = Path(model_path).parent / "BOM"
-            if bom_dir.exists() and bom_dir.is_dir():
-                n_files = len(list(bom_dir.glob("*.json")) + list(bom_dir.glob("*.yaml")) + list(bom_dir.glob("*.yml")))
-                logging.info("BOM: auto-discovered %s (%d asset file(s))", bom_dir, n_files)
-                return str(bom_dir)
-        return None
 
     def export_files_logic(self, markdown_content: str, export_format: str,
                            model_file_path: Optional[str] = None):
@@ -290,9 +225,9 @@ class ExportService:
             try:
                 from threat_analysis.core.gdaf_engine import GDAFEngine
                 from threat_analysis.generation.attack_flow_builder import AttackFlowBuilder
-                _context_path = self._resolve_gdaf_context(threat_model)
+                _context_path = resolve_gdaf_context(threat_model)
                 if _context_path:
-                    _bom_dir = self._resolve_bom_directory(threat_model)
+                    _bom_dir = resolve_bom_directory(threat_model)
                     _gdaf = GDAFEngine(threat_model, _context_path, bom_directory=_bom_dir)
                     _scenarios = _gdaf.run()
                     if _scenarios:

--- a/threat_analysis/utils.py
+++ b/threat_analysis/utils.py
@@ -145,3 +145,79 @@ def _validate_path_within_project(input_path: str, base_dir: Path = PROJECT_ROOT
         raise ValueError(f"Path is outside the allowed project directory: {input_path} (Base: {base_dir_resolved})")
 
     return path_obj
+
+
+def resolve_gdaf_context(threat_model) -> Optional[str]:
+    """Resolve the GDAF context file path for a given threat model.
+    
+    Priority order:
+    1. `gdaf_context` key in the model's ## Context DSL section
+    2. `{model_parent}/context/` directory (first .yaml/.yml found)
+    3. `config/context.yaml` (project default fallback)
+    
+    Returns the resolved path as a string, or None if no context file is found.
+    """
+    import logging
+    
+    ctx_cfg = getattr(threat_model, "context_config", {})
+    dsl_path = ctx_cfg.get("gdaf_context")
+    model_path = getattr(threat_model, "_model_file_path", None)
+    
+    if dsl_path:
+        # Resolve relative to model file directory first
+        if model_path:
+            p = Path(model_path).parent / dsl_path
+            if p.exists():
+                logging.info("GDAF: using context from DSL ## Context: %s", p)
+                return str(p)
+        p = Path(dsl_path)
+        if p.exists():
+            logging.info("GDAF: using context from DSL ## Context: %s", p)
+            return str(p)
+        logging.warning("GDAF: gdaf_context '%s' declared in ## Context but file not found", dsl_path)
+    
+    # Check model parent context/ subdirectory
+    if model_path:
+        context_dir = Path(model_path).parent / "context"
+        if context_dir.exists():
+            yaml_files = list(context_dir.glob("*.yaml")) + list(context_dir.glob("*.yml"))
+            if yaml_files:
+                logging.info("GDAF: using context from model context/ dir: %s", yaml_files[0])
+                return str(yaml_files[0])
+    
+    # Fallback: project default
+    fallback = Path("config/context.yaml")
+    if fallback.exists():
+        return str(fallback)
+    return None
+
+
+def resolve_bom_directory(threat_model) -> Optional[str]:
+    """Resolve BOM directory: DSL ## Context bom_directory → {model_parent}/BOM/ → None."""
+    import logging
+    
+    ctx_cfg = getattr(threat_model, "context_config", {})
+    dsl_path = ctx_cfg.get("bom_directory")
+    model_path = getattr(threat_model, "_model_file_path", None)
+    
+    if dsl_path:
+        # Resolve relative to model file directory first
+        if model_path:
+            p = Path(model_path).parent / dsl_path
+            if p.exists():
+                logging.info("BOM: using directory from DSL ## Context: %s", p)
+                return str(p)
+        p = Path(dsl_path)
+        if p.exists():
+            logging.info("BOM: using directory from DSL ## Context: %s", p)
+            return str(p)
+        logging.warning("BOM: bom_directory '%s' declared in ## Context but not found", dsl_path)
+    
+    # Auto-discover from model file parent
+    if model_path:
+        bom_dir = Path(model_path).parent / "BOM"
+        if bom_dir.exists() and bom_dir.is_dir():
+            n_files = len(list(bom_dir.glob("*.json")) + list(bom_dir.glob("*.yaml")) + list(bom_dir.glob("*.yml")))
+            logging.info("BOM: auto-discovered %s (%d asset file(s))", bom_dir, n_files)
+            return str(bom_dir)
+    return None


### PR DESCRIPTION
## Problem
GDAF (Goal-Driven Attack Flow) scenarios were generated but not displayed in global_threat_report.html for project mode.

## Root Cause
In `generate_global_project_report()`, a new `dummy_model` was created but `gdaf_scenarios` from `main_threat_model` were not copied to it.

## Solution
1. Moved GDAF execution from `export_service.py` to `report_generator.py` (before global report generation)
2. Added helper methods `_resolve_gdaf_context()` and `_resolve_bom_directory()` to `ReportGenerator`
3. Copy `gdaf_scenarios` from `main_threat_model` to `dummy_model` in `generate_global_project_report()`

## Files Changed
- `threat_analysis/generation/report_generator.py` (+106 lines)
- `threat_analysis/server/export_service.py` (-23 lines)

## Testing
- Verified GDAF runs in project mode
- Verified global_threat_report.html now displays GDAF scenarios