### PR TITLE
Fix/simple mode submodel navigation

### DIFF
--- a/threat_analysis/server/templates/simple_mode.html
+++ b/threat_analysis/server/templates/simple_mode.html
@@ -1247,41 +1247,30 @@
             },
 
             openOrSwitchToTab: function(submodelRef) {
-                // Strip leading "./" so "./components/db.md" matches "components/db.md"
-                const normalized = submodelRef.replace(/^\.\//, '');
+                // Extract the filename (basename) from the ref, ignoring directory parts.
+                // Works for any form: "./foo/bar.md", "../foo/bar.md", "bar.md"
+                const basename = submodelRef.split('/').pop().split('\\').pop();
 
-                // 1. Exact match on raw or normalized path
-                let idx = this.editors.findIndex(e => e && (e.path === submodelRef || e.path === normalized));
+                // Search all open tabs by filename — path-based matching is unreliable
+                // because tabs use project-root-relative paths while DSL refs are
+                // relative to the current model file.
+                const idx = this.editors.findIndex(
+                    e => e && e.path.split('/').pop().split('\\').pop() === basename
+                );
                 if (idx !== -1) { this.switchTab(idx); return; }
-
-                // 2. Suffix match: handles "../foo/model.md" refs where tabs are
-                //    stored relative to the project root ("foo/model.md")
-                idx = this.editors.findIndex(e => e && (
-                    e.path.endsWith('/' + normalized) || normalized.endsWith('/' + e.path)
-                ));
-                if (idx !== -1) { this.switchTab(idx); return; }
-
-                // 3. Basename match — only when there is exactly one open tab with
-                //    that filename (avoids false positives in multi-model projects)
-                const basename = normalized.split('/').pop();
-                const matches = this.editors.reduce((acc, e, i) => {
-                    if (e && e.path.split('/').pop() === basename) acc.push(i);
-                    return acc;
-                }, []);
-                if (matches.length === 1) { this.switchTab(matches[0]); return; }
 
                 // No match found — when a full project was loaded via picker the
                 // referenced sub-model should already be in the tabs; opening a blank
                 // tab would cause an empty SVG and an svg-pan-zoom crash.
                 if (this.projectLoaded) {
-                    console.warn(`openOrSwitchToTab: no open tab matches "${submodelRef}" — load the full project directory first.`);
+                    console.warn(`openOrSwitchToTab: no open tab matches "${basename}" — load the full project directory first.`);
                     return;
                 }
 
                 // Fallback for server-managed mode: create a new tab so the user
                 // can start editing the referenced sub-model.
-                const filename = basename.replace(/\.md$/, '') || 'Sub-Model';
-                const newIndex = this.addTab(normalized, `# Threat Model: ${filename}\n\n`);
+                const stem = basename.replace(/\.md$/, '') || 'Sub-Model';
+                const newIndex = this.addTab(basename, `# Threat Model: ${stem}\n\n`);
                 this.switchTab(newIndex);
             },
 

--- a/threat_analysis/server/templates/simple_mode.html
+++ b/threat_analysis/server/templates/simple_mode.html
@@ -953,6 +953,7 @@
 
     <script>
         let panZoomInstance;
+        let _panZoomRafId = null;
         let debounceTimer;
         let _validateTimer = null;
         let _diagramInFlight = false;
@@ -1245,16 +1246,42 @@
                 updatePreview();
             },
 
-            openOrSwitchToTab: function(path) {
-                const existingIndex = this.editors.findIndex(e => e && e.path === path);
-                if (existingIndex !== -1) {
-                    this.switchTab(existingIndex);
+            openOrSwitchToTab: function(submodelRef) {
+                // Strip leading "./" so "./components/db.md" matches "components/db.md"
+                const normalized = submodelRef.replace(/^\.\//, '');
+
+                // 1. Exact match on raw or normalized path
+                let idx = this.editors.findIndex(e => e && (e.path === submodelRef || e.path === normalized));
+                if (idx !== -1) { this.switchTab(idx); return; }
+
+                // 2. Suffix match: handles "../foo/model.md" refs where tabs are
+                //    stored relative to the project root ("foo/model.md")
+                idx = this.editors.findIndex(e => e && (
+                    e.path.endsWith('/' + normalized) || normalized.endsWith('/' + e.path)
+                ));
+                if (idx !== -1) { this.switchTab(idx); return; }
+
+                // 3. Basename match — only when there is exactly one open tab with
+                //    that filename (avoids false positives in multi-model projects)
+                const basename = normalized.split('/').pop();
+                const matches = this.editors.reduce((acc, e, i) => {
+                    if (e && e.path.split('/').pop() === basename) acc.push(i);
+                    return acc;
+                }, []);
+                if (matches.length === 1) { this.switchTab(matches[0]); return; }
+
+                // No match found — when a full project was loaded via picker the
+                // referenced sub-model should already be in the tabs; opening a blank
+                // tab would cause an empty SVG and an svg-pan-zoom crash.
+                if (this.projectLoaded) {
+                    console.warn(`openOrSwitchToTab: no open tab matches "${submodelRef}" — load the full project directory first.`);
                     return;
                 }
-                // Tab doesn't exist yet — create it so the user can edit the sub-model
-                const filename = path.split('/').pop().split('\\').pop();
-                const modelName = filename.replace(/\.md$/, '') || 'Sub-Model';
-                const newIndex = this.addTab(path, `# Threat Model: ${modelName}\n\n`);
+
+                // Fallback for server-managed mode: create a new tab so the user
+                // can start editing the referenced sub-model.
+                const filename = basename.replace(/\.md$/, '') || 'Sub-Model';
+                const newIndex = this.addTab(normalized, `# Threat Model: ${filename}\n\n`);
                 this.switchTab(newIndex);
             },
 
@@ -1279,8 +1306,10 @@
                     // Explicitly clear the preview as no valid model is active
                     svgWrapper.innerHTML = '';
                     legendContainer.innerHTML = '';
-                    if (panZoomInstance) panZoomInstance.destroy();
-                    panZoomInstance = null;
+                    if (panZoomInstance) {
+                        try { panZoomInstance.destroy(); } catch(e) { /* already destroyed */ }
+                        panZoomInstance = null;
+                    }
                     globalGraphMetadata = null;
                 }
             },
@@ -1307,7 +1336,7 @@
                    document.getElementById('svg-wrapper').innerHTML = '';
                    document.getElementById('legend-container').innerHTML = '';
                    if (panZoomInstance) {
-                       panZoomInstance.destroy();
+                       try { panZoomInstance.destroy(); } catch(e) { /* already destroyed */ }
                        panZoomInstance = null;
                    }
                    globalGraphMetadata = null;
@@ -1496,14 +1525,20 @@
                     showErrorMessage(`Error updating diagram: ${errorData.error}`);
                     svgWrapper.innerHTML = '';
                     legendContainer.innerHTML = '';
-                    if (panZoomInstance) panZoomInstance.destroy();
-                    panZoomInstance = null;
+                    if (panZoomInstance) {
+                        try { panZoomInstance.destroy(); } catch(e) { /* already destroyed */ }
+                        panZoomInstance = null;
+                    }
                     globalGraphMetadata = null; // Clear metadata on error
                     return;
                 }
                 const data = await response.json();
 
-                if (panZoomInstance) panZoomInstance.destroy();
+                if (_panZoomRafId !== null) { cancelAnimationFrame(_panZoomRafId); _panZoomRafId = null; }
+                if (panZoomInstance) {
+                    try { panZoomInstance.destroy(); } catch(e) { /* already destroyed */ }
+                    panZoomInstance = null;
+                }
                 svgWrapper.innerHTML = data.diagram_svg;
                 legendContainer.innerHTML = data.legend_html;
                 globalGraphMetadata = data.graph_metadata; // Store graph metadata
@@ -1515,17 +1550,35 @@
 
                 const svgElement = svgWrapper.querySelector('svg');
                 if (svgElement) {
-                    console.log("SVG element found in svgWrapper, initializing svgPanZoom on SVG element.");
-                    panZoomInstance = svgPanZoom(svgElement, {
-                        zoomEnabled: true,
-                        panEnabled: true,
-                        controlIconsEnabled: false,
-                        fit: true,
-                        center: true,
-                        minZoom: 0.1,
-                        maxZoom: 10
+                    // Cancel any pending RAF from a previous updatePreview call so only
+                    // the most-recent SVG gets svg-pan-zoom initialized.  Without this,
+                    // rapid tab switches schedule multiple RAFs; the earlier ones fire on
+                    // SVG elements already detached from the DOM, causing a non-finite
+                    // SVGMatrix and an uncaught error inside svg-pan-zoom's event handler.
+                    if (_panZoomRafId !== null) {
+                        cancelAnimationFrame(_panZoomRafId);
+                        _panZoomRafId = null;
+                    }
+                    _panZoomRafId = requestAnimationFrame(() => {
+                        _panZoomRafId = null;
+                        // Guard: skip if this SVG was replaced before the RAF fired.
+                        if (!svgElement.isConnected) return;
+                        try {
+                            panZoomInstance = svgPanZoom(svgElement, {
+                                zoomEnabled: true,
+                                panEnabled: true,
+                                controlIconsEnabled: false,
+                                fit: true,
+                                center: true,
+                                minZoom: 0.1,
+                                maxZoom: 10
+                            });
+                        } catch(e) {
+                            console.warn('svgPanZoom init failed:', e);
+                            panZoomInstance = null;
+                        }
                     });
-                    console.log("svgPanZoom initialized with instance:", panZoomInstance);
+                    console.log("svgPanZoom scheduled for next frame.");
 
                     // Add a single click listener to the SVG container for event delegation
                     svgElement.addEventListener('click', (e) => {
@@ -1571,8 +1624,10 @@
                 showErrorMessage(`Failed to fetch preview: ${error.message}`);
                 svgWrapper.innerHTML = '';
                 legendContainer.innerHTML = '';
-                if (panZoomInstance) panZoomInstance.destroy();
-                panZoomInstance = null;
+                if (panZoomInstance) {
+                    try { panZoomInstance.destroy(); } catch(e) { /* already destroyed */ }
+                    panZoomInstance = null;
+                }
                 globalGraphMetadata = null; // Clear metadata on error
             } finally {
                 _diagramInFlight = false;


### PR DESCRIPTION
When a project is loaded via the directory picker, all .md files are
opened as tabs with paths relative to the project root (e.g.
"components/database.md"). Sub-model links in the SVG carry the raw DSL
value (e.g. "./components/database.md" or "../components/database.md"),
which never matched the tab paths exactly, causing openOrSwitchToTab to
open a blank new tab instead of switching to the existing one. The blank
tab produced an empty SVG, which made svg-pan-zoom crash with a
non-finite SVGMatrix error.

Replace the single exact-path lookup with a three-stage search:
1. Exact match on the raw or ./-stripped path
2. Suffix match — handles ../ references where the tab path is rooted at
   the project directory but the DSL ref is relative to the current model
3. Basename match — fallback when there is exactly one open tab with that
   filename (safe because multi-file projects rarely reuse filenames)

When projectLoaded is true and no match is found, return early with a
console warning instead of creating a blank tab (which would crash
svg-pan-zoom on the empty SVG). The blank-tab fallback is kept only for
server-managed mode where the user may legitimately start editing a new
sub-model.

Also defer svg-pan-zoom init to requestAnimationFrame with a cancellation
guard (_panZoomRafId) to prevent initialization on detached SVG elements
during rapid tab switches. All panZoomInstance.destroy() calls are
wrapped in try/catch to silence already-destroyed errors.