### PR TITLE
fix: GDAF not working in --model-file CLI mode

### DIFF
--- a/threat_analysis/__main__.py
+++ b/threat_analysis/__main__.py
@@ -201,6 +201,10 @@ class SecOpsTMFramework:
 
         logging.info("📊 Generating reports...")
 
+        # Run GDAF engine before HTML report generation
+        from threat_analysis.utils import run_gdaf_engine
+        run_gdaf_engine(self.threat_model, export_path=Path(self.output_base_dir))
+
         html_output_full_path = os.path.join(
             self.output_base_dir, self.html_report_filename
         )
@@ -215,7 +219,6 @@ class SecOpsTMFramework:
             self.threat_model, self.grouped_threats, Path(json_output_full_path)
         )
         logging.info("✅ Reports generated.")
-        return {"html": str(html_report_path), "json": str(json_report_path)}
         return {"html": str(html_report_path), "json": str(json_report_path)}
 
     def generate_stix_report(self) -> Optional[str]:

--- a/threat_analysis/generation/report_generator.py
+++ b/threat_analysis/generation/report_generator.py
@@ -1636,25 +1636,14 @@ class ReportGenerator:
 
             # GDAF: Goal-Driven Attack Flow (run BEFORE global report so scenarios are available)
             try:
-                from threat_analysis.core.gdaf_engine import GDAFEngine
-                from threat_analysis.generation.attack_flow_builder import AttackFlowBuilder
-                _context_path = resolve_gdaf_context(main_threat_model)
-                if _context_path:
-                    if progress_callback: progress_callback(94, "Running GDAF cross-model analysis...")
-                    _extra = getattr(main_threat_model, "sub_models", [])
-                    _bom_dir = resolve_bom_directory(main_threat_model)
-                    _gdaf = GDAFEngine(main_threat_model, _context_path, extra_models=_extra, bom_directory=_bom_dir)
-                    _scenarios = _gdaf.run()
-                    if _scenarios:
-                        main_threat_model.gdaf_scenarios = _scenarios
-                        _builder = AttackFlowBuilder(_scenarios, model_name=str(main_threat_model.tm.name))
-                        _builder.generate_and_save(str(output_dir))
-                        logging.info(
-                            "GDAF (project): %d scenarios from %d model(s) in %s/gdaf",
-                            len(_scenarios), 1 + len(_extra), output_dir,
-                        )
-                    else:
-                        logging.info("GDAF (project): no scenarios produced")
+                if progress_callback: progress_callback(94, "Running GDAF cross-model analysis...")
+                from threat_analysis.utils import run_gdaf_engine
+                _scenarios = run_gdaf_engine(main_threat_model, export_path=output_dir)
+                if _scenarios:
+                    logging.info(
+                        "GDAF (project): %d scenarios from %d model(s) in %s/gdaf",
+                        len(_scenarios), 1 + len(getattr(main_threat_model, "sub_models", [])), output_dir,
+                    )
             except Exception as _gdaf_exc:
                 logging.warning("GDAF (project) generation skipped (non-fatal): %s", _gdaf_exc)
 

--- a/threat_analysis/generation/report_generator.py
+++ b/threat_analysis/generation/report_generator.py
@@ -1636,9 +1636,8 @@ class ReportGenerator:
 
             # GDAF: Goal-Driven Attack Flow (run BEFORE global report so scenarios are available)
             try:
-                if progress_callback: progress_callback(94, "Running GDAF cross-model analysis...")
                 from threat_analysis.utils import run_gdaf_engine
-                _scenarios = run_gdaf_engine(main_threat_model, export_path=output_dir)
+                _scenarios = run_gdaf_engine(main_threat_model, export_path=output_dir, progress_callback=progress_callback)
                 if _scenarios:
                     logging.info(
                         "GDAF (project): %d scenarios from %d model(s) in %s/gdaf",

--- a/threat_analysis/server/export_service.py
+++ b/threat_analysis/server/export_service.py
@@ -223,20 +223,10 @@ class ExportService:
             # GDAF: Goal-Driven Attack Flow (objective-based, requires context with attack_objectives)
             # Run BEFORE the HTML report so that gdaf_scenarios are available in the report.
             try:
-                from threat_analysis.core.gdaf_engine import GDAFEngine
-                from threat_analysis.generation.attack_flow_builder import AttackFlowBuilder
-                _context_path = resolve_gdaf_context(threat_model)
-                if _context_path:
-                    _bom_dir = resolve_bom_directory(threat_model)
-                    _gdaf = GDAFEngine(threat_model, _context_path, bom_directory=_bom_dir)
-                    _scenarios = _gdaf.run()
-                    if _scenarios:
-                        threat_model.gdaf_scenarios = _scenarios
-                        _builder = AttackFlowBuilder(_scenarios, model_name=str(threat_model.tm.name))
-                        _builder.generate_and_save(str(export_path))
-                        logging.info("GDAF: generated %d attack scenarios in %s/gdaf", len(_scenarios), export_path)
-                    else:
-                        logging.info("GDAF: no scenarios produced (check context attack_objectives/threat_actors)")
+                from threat_analysis.utils import run_gdaf_engine
+                _scenarios = run_gdaf_engine(threat_model, export_path=export_path)
+                if _scenarios:
+                    logging.info("GDAF: generated %d attack scenarios in %s/gdaf", len(_scenarios), export_path)
             except Exception as e:
                 logging.warning("GDAF generation skipped (non-fatal): %s", e)
 

--- a/threat_analysis/utils.py
+++ b/threat_analysis/utils.py
@@ -218,7 +218,7 @@ def resolve_bom_directory(threat_model) -> Optional[str]:
     return None
 
 
-def run_gdaf_engine(threat_model, export_path=None):
+def run_gdaf_engine(threat_model, export_path=None, progress_callback=None):
     """Run GDAF engine on a threat model and attach scenarios.
     
     This is a common function used by:
@@ -229,6 +229,8 @@ def run_gdaf_engine(threat_model, export_path=None):
     Args:
         threat_model: ThreatModel instance
         export_path: Optional path to save Attack Flow files (Path or str)
+        progress_callback: Optional callback function(progress_percent, message) 
+                          called after confirming context file exists
     
     Returns:
         List of AttackScenario objects, or empty list if none generated
@@ -242,6 +244,9 @@ def run_gdaf_engine(threat_model, export_path=None):
         if not _context_path:
             logging.debug("GDAF: no context file found, skipping.")
             return []
+        
+        if progress_callback:
+            progress_callback(94, "Running GDAF cross-model analysis...")
         
         _bom_dir = resolve_bom_directory(threat_model)
         _extra = getattr(threat_model, "sub_models", [])

--- a/threat_analysis/utils.py
+++ b/threat_analysis/utils.py
@@ -200,11 +200,11 @@ def resolve_bom_directory(threat_model) -> Optional[str]:
         if model_path:
             p = Path(model_path).parent / dsl_path
             if p.exists():
-                logging.info("BOM: using directory from DSL ## Context: %s", p)
+                logging.info("BOM: using context from DSL ## Context: %s", p)
                 return str(p)
         p = Path(dsl_path)
         if p.exists():
-            logging.info("BOM: using directory from DSL ## Context: %s", p)
+            logging.info("BOM: using context from DSL ## Context: %s", p)
             return str(p)
         logging.warning("BOM: bom_directory '%s' declared in ## Context but not found", dsl_path)
     
@@ -216,3 +216,53 @@ def resolve_bom_directory(threat_model) -> Optional[str]:
             logging.info("BOM: auto-discovered %s (%d asset file(s))", bom_dir, n_files)
             return str(bom_dir)
     return None
+
+
+def run_gdaf_engine(threat_model, export_path=None):
+    """Run GDAF engine on a threat model and attach scenarios.
+    
+    This is a common function used by:
+    - SecOpsTMFramework.generate_reports() (CLI --model-file mode)
+    - ExportService.export_single_file_logic() (Server mode)
+    - ReportGenerator.generate_project_reports() (Project mode)
+    
+    Args:
+        threat_model: ThreatModel instance
+        export_path: Optional path to save Attack Flow files (Path or str)
+    
+    Returns:
+        List of AttackScenario objects, or empty list if none generated
+    """
+    import logging
+    try:
+        from threat_analysis.core.gdaf_engine import GDAFEngine
+        from threat_analysis.generation.attack_flow_builder import AttackFlowBuilder
+        
+        _context_path = resolve_gdaf_context(threat_model)
+        if not _context_path:
+            logging.debug("GDAF: no context file found, skipping.")
+            return []
+        
+        _bom_dir = resolve_bom_directory(threat_model)
+        _extra = getattr(threat_model, "sub_models", [])
+        
+        _gdaf = GDAFEngine(threat_model, _context_path, extra_models=_extra, bom_directory=_bom_dir)
+        _scenarios = _gdaf.run()
+        
+        if _scenarios:
+            threat_model.gdaf_scenarios = _scenarios
+            
+            # Generate Attack Flow files if export_path provided
+            if export_path:
+                _builder = AttackFlowBuilder(_scenarios, model_name=str(threat_model.tm.name))
+                _builder.generate_and_save(str(export_path))
+            
+            logging.info("GDAF: generated %d attack scenarios", len(_scenarios))
+        else:
+            logging.info("GDAF: no scenarios produced (check context attack_objectives/threat_actors)")
+        
+        return _scenarios
+    
+    except Exception as e:
+        logging.warning("GDAF generation skipped (non-fatal): %s", e)
+        return []


### PR DESCRIPTION
Problem: GDAF engine was only called in project mode and server mode, but not in single-file CLI mode (--model-file).

Solution: Extract common GDAF execution logic to utils.py as run_gdaf_engine() function, reused by all three modes:
- SecOpsTMFramework.generate_reports() (CLI --model-file)
- ExportService.export_single_file_logic() (Server mode)
- ReportGenerator.generate_project_reports() (Project mode)

Changes:
- utils.py: Add run_gdaf_engine() common function (+54 lines)
- __main__.py: Call run_gdaf_engine() in generate_reports() (+5 lines)
- report_generator.py: Refactor to use run_gdaf_engine() (-23 lines)
- export_service.py: Refactor to use run_gdaf_engine() (-18 lines)

Benefits:
- DRY principle: Single source of truth
- Consistency: All modes use same GDAF logic
- Maintainability: Changes only need one place update
- Testability: Common function easier to unit test

Tested:
- CLI --model-file: ✅ GDAF scenarios generated
- CLI --project: ✅ Still working
- Server: ✅ Still working