### PR TITLE
feat: make enable_thinking configurable per provider in ai_config.yaml

### DIFF
--- a/config/ai_config.yaml
+++ b/config/ai_config.yaml
@@ -33,6 +33,7 @@ ai_providers:
     max_tokens: 4096
     timeout: 30
     ssl_verify: true   # false | "/path/to/ca-bundle.crt" for self-signed certs
+    # enable_thinking: false  # Anthropic extended thinking — set true only with a large max_tokens budget
 
   gemini:
     enabled: false

--- a/tests/test_litellm_provider.py
+++ b/tests/test_litellm_provider.py
@@ -180,6 +180,70 @@ def test_litellm_client_file_not_found():
             assert client.ai_config == {}
     asyncio.run(_run())
 
+# --- enable_thinking config tests ---
+
+def test_enable_thinking_defaults_to_false():
+    """enable_thinking must be False when not set in provider config."""
+    async def _run():
+        client = LiteLLMClient()
+        client.ai_online = True
+        client.model_name = "openai/test"
+        client.provider_config = {}
+        client.ai_config = {}
+        client.stream = False
+        client._litellm_module = MagicMock()
+
+        mock_response = MagicMock()
+        mock_response.choices[0].message.content = "ok"
+        client._litellm_module.acompletion = AsyncMock(return_value=mock_response)
+
+        async for _ in client.generate_content("p", "s", stream=False):
+            pass
+
+        call_kwargs = client._litellm_module.acompletion.call_args[1]
+        assert call_kwargs["enable_thinking"] is False
+    asyncio.run(_run())
+
+
+def test_enable_thinking_true_from_provider_config():
+    """enable_thinking=True is forwarded to acompletion when set in provider config."""
+    async def _run():
+        client = LiteLLMClient()
+        client.ai_online = True
+        client.model_name = "anthropic/claude-3-5-sonnet"
+        client.provider_config = {"enable_thinking": True, "max_tokens": 8192, "temperature": 0.7}
+        client.ai_config = {}
+        client.stream = False
+        client._litellm_module = MagicMock()
+
+        mock_response = MagicMock()
+        mock_response.choices[0].message.content = "ok"
+        client._litellm_module.acompletion = AsyncMock(return_value=mock_response)
+
+        async for _ in client.generate_content("p", "s", stream=False):
+            pass
+
+        call_kwargs = client._litellm_module.acompletion.call_args[1]
+        assert call_kwargs["enable_thinking"] is True
+    asyncio.run(_run())
+
+
+def test_check_connection_does_not_pass_enable_thinking():
+    """check_connection health ping must not pass enable_thinking (max_tokens=1, param is useless there)."""
+    async def _run():
+        client = LiteLLMClient()
+        client.model_name = "openai/test"
+        client.provider_config = {"enable_thinking": True}
+        client._litellm_module = MagicMock()
+        client._litellm_module.acompletion = AsyncMock(return_value=MagicMock())
+
+        await client.check_connection()
+
+        call_kwargs = client._litellm_module.acompletion.call_args[1]
+        assert "enable_thinking" not in call_kwargs
+    asyncio.run(_run())
+
+
 # --- LiteLLMProvider Tests ---
 
 def test_litellm_provider_check_connection():

--- a/threat_analysis/ai_engine/providers/litellm_client.py
+++ b/threat_analysis/ai_engine/providers/litellm_client.py
@@ -186,7 +186,6 @@ class LiteLLMClient:
                 timeout=self.provider_config.get('timeout', 10),
                 stream=False,
                 api_base=self.api_base,
-                enable_thinking=False,
             )
             logging.info("[%.3fs] AI health check OK — %s", time.time() - check_start_time, self.model_name)
             self.ai_online = True
@@ -225,7 +224,7 @@ class LiteLLMClient:
             "timeout": effective_timeout,
             "num_retries": int(self.ai_config.get("threat_generation", {}).get("num_retries", 3)),
             "api_base": self.api_base,
-            "enable_thinking": False,
+            "enable_thinking": bool(self.provider_config.get("enable_thinking", False)),
         }
         if "top_p" in self.provider_config:
             completion_params["top_p"] = self.provider_config["top_p"]


### PR DESCRIPTION
 enable_thinking was hardcoded to False in litellm_client.py (PR #33). This moves it to a per-provider config field so Anthropic extended thinking can be enabled when a sufficient
  max_tokens budget is available.

  threat_analysis/ai_engine/providers/litellm_client.py
  - generate_content(): replace hardcoded False with bool(self.provider_config.get("enable_thinking", False)) — reads from ai_config.yaml, defaults to False
  - check_connection(): remove enable_thinking=False — the health ping uses max_tokens=1 and never benefits from reasoning mode

  config/ai_config.yaml
  - Add enable_thinking as a commented-out field under the mistral provider block, with a note that it should only be set to true alongside a large max_tokens budget

  tests/test_litellm_provider.py
  - test_enable_thinking_defaults_to_false: asserts acompletion receives enable_thinking=False when the field is absent from provider config
  - test_enable_thinking_true_from_provider_config: asserts enable_thinking=True is forwarded to acompletion when explicitly set in provider config
  - test_check_connection_does_not_pass_enable_thinking: asserts enable_thinking is absent from the health check call regardless of provider config